### PR TITLE
Use proxy repo

### DIFF
--- a/src/main/g8/.gitlab/renovate.json
+++ b/src/main/g8/.gitlab/renovate.json
@@ -5,5 +5,15 @@
     ":disableDependencyDashboard"
   ],
   "prConcurrentLimit": 15,
-  "branchConcurrentLimit": 15
+  "branchConcurrentLimit": 15,
+  "packageRules": [
+    {
+      "matchDatasources": [
+        "maven"
+      ],
+      "registryUrls": [
+        "https://pirum-scala-976632135703.d.codeartifact.eu-west-2.amazonaws.com/maven/internal/"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
The renovate bot pulls from the internal proxy maven repository.